### PR TITLE
refactor(taskqueue): avoid caught TypeError in backoff reset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
         - -d invalid-name
         - -d locally-disabled
         - -d missing-docstring
+        - -d unused-variable
 -   repo: git://github.com/Lucas-C/pre-commit-hooks
     sha: v1.1.4
     hooks:

--- a/gcloud/rest/core/util.py
+++ b/gcloud/rest/core/util.py
@@ -14,10 +14,13 @@ def backoff(base=2, factor=1.1, max_value=None):
         if no_items_in_queue:
             time.sleep(next(my_backoff))
         else:
+            my_backoff.send(None)
             my_backoff.send('reset')
 
     If its more convenient, you can re-initialize the generator rather than
-    sending the `reset` event.
+    sending the `reset` event. Note that `None` is sent first to ensure the
+    generator has begun iteration. Otherwise, sending the `reset` event may
+    throw a TypeError.
 
     Params:
 

--- a/gcloud/rest/taskqueue/manager.py
+++ b/gcloud/rest/taskqueue/manager.py
@@ -72,12 +72,8 @@ class TaskManager(object):
     def find_tasks_forever(self):
         while not self.stop_event.is_set():
             self.find_and_process_work()
-            try:
-                self.backoff.send('reset')
-            except TypeError:
-                # a TypeError is thrown when attempting to `send()` to a newly-
-                # created generator
-                pass
+            self.backoff.send(None)
+            self.backoff.send('reset')
 
     def find_and_process_work(self):
         """


### PR DESCRIPTION
The default config for the GCloud error console has been showing these `TypeError`s, even though they're caught. This should not change behaviour, but will ensure not `TypeError`s end up in our console.