### PR TITLE
chore(dependencies): ensure cryptography is installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-api-python-client >= 1.0.0, < 2.0.0
 oauth2client >= 4.0.0, < 5.0.0
 pyjwt >= 1.5.3, < 2.0.0
-requests >= 2.0.0, < 3.0.0
+requests[security] >= 2.0.0, < 3.0.0


### PR DESCRIPTION
We need `cryptography` (part of the `security` bundle in `requests`) for the RSA encryption.