### PR TITLE
Fix threading model for renewing leases

### DIFF
--- a/tests/integration/taskqueue/manager_test.py
+++ b/tests/integration/taskqueue/manager_test.py
@@ -1,11 +1,14 @@
 import json
 import os
+import time
+
+import pytest
 
 from gcloud.rest.taskqueue import encode
 from gcloud.rest.taskqueue import TaskManager
 
 
-def test_lifecycle(mocker):
+def test_lifecycle(caplog, mocker):
     project = os.environ['GCLOUD_PROJECT']
     task_queue = 'test-pull'
 
@@ -27,7 +30,43 @@ def test_lifecycle(mocker):
     # insert new ones
     for task in tasks:
         tm.tq.insert(encode(json.dumps(task)),
-                     tag=encode('gcloud-rest-manager-test'))
+                     tag=encode('gcloud-rest-manager-test-lifecycle'))
 
     tm.find_and_process_work()
     assert worker.mock_calls == [mocker.call(tasks)]
+    for record in caplog.records:
+        assert record.levelname != 'ERROR'
+
+
+@pytest.mark.slow
+def test_multiple_leases(caplog, mocker):
+    project = os.environ['GCLOUD_PROJECT']
+    task_queue = 'test-pull'
+
+    tasks = [
+        {'test_idx': 1},
+        {'test_idx': 2},
+    ]
+
+    def succeed_after_multiple_leases(ts):
+        time.sleep(10)
+        return ['ok' for _ in ts]
+
+    worker = mocker.Mock()
+    worker.side_effect = succeed_after_multiple_leases
+
+    tm = TaskManager(project, task_queue, worker, batch_size=len(tasks),
+                     lease_seconds=4)
+
+    # drain old test tasks
+    drain = tm.tq.drain()
+
+    # insert new ones
+    for task in tasks:
+        tm.tq.insert(encode(json.dumps(task)),
+                     tag=encode('gcloud-rest-manager-test-multilease'))
+
+    tm.find_and_process_work()
+    assert worker.mock_calls == [mocker.call(tasks)]
+    for record in caplog.records:
+        assert record.levelname != 'ERROR'


### PR DESCRIPTION
The crux of this issue is that the `task` entity we lease from cloudtasks API gets _mutated_ on a renew, so any future renews, acks, and cancels need access to the mutated task.

This change is twofold:
- the TaskManager stores the leased/renewed tasks in a class-level dict and updates those entities on each lease, then uses those entities when it checks the task results.
- after setting the `end_lease_events`, we explicitly wait for each `lease_manager` thread to terminate. This prevents the potential race condition created by the above (ie. the lease manager renews a task and mutates the class-level dict as we attempt to ack/cancel from the un-renewed task