### PR TITLE
chore(pre-commit) upgrade hooks and add some from gcloud-aio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,9 @@
 version: 2
 
 jobs:
-  lint-py2:
-    docker:
-      - image: python:2.7.14
-    steps:
-      - checkout
-      - run: pip install pre-commit
-      - restore_cache:
-          keys:
-            - cache-pre-commit2-{{ checksum ".pre-commit-config.yaml" }}
-      - run: pre-commit run --all-files
-      - save_cache:
-          key: cache-pre-commit2-{{ checksum ".pre-commit-config.yaml" }}
-          paths:
-            - ~/.cache/pre-commit
-
   lint-py3:
     docker:
-      - image: python:3.6.2
+      - image: python:3.7.4
     steps:
       - checkout
       - run: pip install pre-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   lint-py3:
     docker:
-      - image: python:3.7.4
+      - image: python:3.7.3
     steps:
       - checkout
       - run: pip install pre-commit
@@ -63,10 +63,6 @@ workflows:
   version: 2
   run-jobs:
     jobs:
-      - lint-py2:
-          filters:
-            tags:
-              only: /.*/
       - lint-py3:
           filters:
             tags:
@@ -85,7 +81,6 @@ workflows:
             tags:
               only: /[0-9]+\.[0-9]+\.[0-9]+/
           requires:
-            - lint-py2
             - lint-py3
             - test
       - github:
@@ -96,6 +91,5 @@ workflows:
             tags:
               only: /[0-9]+\.[0-9]+\.[0-9]+/
           requires:
-            - lint-py2
             - lint-py3
             - test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v1.2.3
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
     hooks:
     -   id: check-ast
     -   id: check-builtin-literals
-        args: [--no-allow-dict-kwargs]
     -   id: check-case-conflict
+    -   id: check-docstring-first
     -   id: check-executables-have-shebangs
     -   id: check-json
     -   id: check-merge-conflict
@@ -19,29 +19,42 @@ repos:
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
     -   id: file-contents-sorter
-        files: .gitignore
+        files: .(docker|git)ignore
     -   id: mixed-line-ending
         args: [--fix=lf]
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
--   repo: git://github.com/pre-commit/mirrors-pylint
-    sha: v1.8.4
+-   repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v2.3.1
     hooks:
     -   id: pylint
         args:
+        - --max-line-length=80
+        - --ignore-imports=yes
         - -d duplicate-code
         - -d fixme
         - -d import-error
         - -d invalid-name
         - -d locally-disabled
         - -d missing-docstring
--   repo: git://github.com/Lucas-C/pre-commit-hooks
-    sha: v1.1.5
+        - -d too-few-public-methods
+        - -d too-many-arguments
+        - -d useless-object-inheritance # Necessary for Python 2 compatibility
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.6
     hooks:
     -   id: remove-crlf
     -   id: remove-tabs
--   repo: git://github.com/asottile/reorder_python_imports
-    sha: v1.0.1
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.3.4
     hooks:
     -   id: reorder-python-imports
+-   repo: https://github.com/asottile/yesqa
+    rev: v0.0.8
+    hooks:
+    -   id: yesqa
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-markup
+    rev: v1.0.0
+    hooks:
+    -   id: rst-linter


### PR DESCRIPTION
Originally I was just upgrading pylint (because pylint 1.x doesn't work with Python 3.7), but then I thought I should have a look at what we're going in [gcloud-aio](https://github.com/talkiq/gcloud-aio/blob/master/.pre-commit-config.yaml).

So I upgraded the hooks and added `yesqa` and `pre-commit-hooks-markup` from there. I didn't add `pyupgrade` because it didn't seem that useful, given that we need to keep Python 2.7.